### PR TITLE
chore: fix `.editorconfig` for Rust

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,7 @@ trim_trailing_whitespace = false
 
 [*.rs]
 indent_style = space
-indent_size = 2
+indent_size = 4
 
 [*.toml]
 indent_style = space

--- a/src-tauri/.editorconfig
+++ b/src-tauri/.editorconfig
@@ -1,0 +1,1 @@
+../.editorconfig


### PR DESCRIPTION
fix #7